### PR TITLE
Removes Hash from derivation macro

### DIFF
--- a/Chapter02/derive.rs
+++ b/Chapter02/derive.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::fmt::Display;
 
-#[derive(Debug, Hash)]
+#[derive(Debug)]
 struct Point<T> {
     x: T,
     y: T,


### PR DESCRIPTION
The author is careful to explain newly added material. In this example
`Hash` is added with this example without need or introduction while the
`Debug` and `Display` traits have been introduced.

It is probably better to remove it so that it does not confuse or
distract.